### PR TITLE
Changed Link to point to action_aws.md

### DIFF
--- a/actions/action-list.md
+++ b/actions/action-list.md
@@ -4,7 +4,7 @@
 
 |                                                                        |                                                                          |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| [AWS](../connnecting/connectors/aws/action\_aws/)                      | [Airflow](../connnecting/connectors/airflow/action\_airflow.md)          |
+| [AWS](../connnecting/connectors/aws/action\_aws.md)                      | [Airflow](../connnecting/connectors/airflow/action\_airflow.md)          |
 | [ChatGPT](../lists/action\_CHATGPT.md)                                 | [Datadog](../connnecting/connectors/datadog/action\_datadog/)            |
 | [GCP](../connnecting/connectors/gcp/action\_gcp/)                      | [Github](../connnecting/connectors/github/action\_github.md)             |
 | [Hadoop](../connnecting/connectors/hadoop/action\_hadoop.md)           | [Jenkins](../connnecting/connectors/jenkins/action\_jenkins.md)          |


### PR DESCRIPTION
## Fixes

[EN-5029]

Updated the link for AWS Action list to point to aws_action.md instead of the aws_action directory

[EN-5029]: https://unskript.atlassian.net/browse/EN-5029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ